### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 # Denne koden forvaltes av:  Team DigiBok
 
 * @kartverket/digibok
-/.sikkerhet/ @haakl
+/.security/ @haakl

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Eiendom
 product: Grunnbok
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "digibok"
   system: "grunnbok"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_etinglysing-fullmakter"
-  title: "Security Champion etinglysing-fullmakter"
-spec:
-  type: "security_champion"
-  parent: "eiendom_security_champions"
-  members:
-  - "haakl"
-  children:
-  - "resource:etinglysing-fullmakter"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "etinglysing-fullmakter"
-  links:
-  - url: "https://github.com/kartverket/etinglysing-fullmakter"
-    title: "etinglysing-fullmakter på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_etinglysing-fullmakter"
-  dependencyOf:
-  - "component:etinglysing-fullmakter"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml